### PR TITLE
Small improvements

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -79,8 +79,8 @@
               <img src="img/staff/cies.jpg">
               <div class="about">
                 <p class="name">Cies Breijs</p>
-                <p class="description">I'm a dad and a husband and a firm believer in mass-enlightenment. As open source enthousiast who adheres to a mostly vegan diet, I prefer to keep my brain deeply immersed in techno music.</p>
-                <p><a href="https://twitter.com/cies">@cies</a></p>
+                <p class="description">I'm a dad and a husband and a firm believer in mass-enlightenment. An open source enthousiast who adheres to a mostly vegan diet and prefers to keep the brain immersed in techno music.</p>
+                <p><a href="https://twitter.com/cies010">@cies</a></p>
               </div>
             </div>
           </div>
@@ -97,12 +97,6 @@
             <div class="alumni">
               <h3>Alumni</h3>
               <p>Joy of Coding 2016 is the fourth in a series of conferences dedicated to software development. We are very grateful to everyone who has contributed to our conference in the previous editions: Freek Leemhuis, Anna Gos, Jacques Bouman, Mark van Straten, Daan van Berkel, Jettro Coenradie and Marc Lainez.</p>
-            </div>
-            <div class="previous">
-              <h3>Previous editions</h3>
-              <p>2015: <a href="/2015" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2015" target="_blank">videos</a></br>
-              2014: <a href="/2014" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157642055047693" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2014" target="_blank">videos</a></br>
-              2013: <a href="/2013" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157632915801638" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2013" target="_blank">videos</a></p>
             </div>
           </div>
           <div class="col-md-3 col-sm-6">
@@ -124,6 +118,18 @@
             </div>
           </div>
         </div>
+
+
+            <h3>Previous editions</h3>
+	    <p>
+              <div class="video-wrapper">
+                <iframe width="440" height="260" src="https://www.youtube.com/embed/LI2yOM4tODw" frameborder="0" allowfullscreen></iframe>
+              </div>
+	    </p>
+            <p>2015: <a href="/2015" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2015" target="_blank">recorded talks</a> - <a href="https://www.youtube.com/watch?v=LI2yOM4tODw" target="_blank">after movie</a></br>
+            2014: <a href="/2014" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157642055047693" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2014" target="_blank">recorded talks</a></br>
+            2013: <a href="/2013" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157632915801638" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2013" target="_blank">recorded talks</a></p>
+
       </div>
     </div>
 

--- a/css/home.css
+++ b/css/home.css
@@ -98,6 +98,14 @@
   padding: 20px;
 }
 
+.speakers .speaker .more {
+  background-color: white;
+  text-align: center;
+  padding: 10px 10px 1px 10px;
+  font-size: 120%;
+}
+
+
 @media (min-width: 992px) {
   .speakers .speaker .about {
     min-height: 220px;

--- a/css/style.css
+++ b/css/style.css
@@ -156,3 +156,18 @@ a:link, a:active, a:visited, a:hover {
   font-size: 24px;
   margin: 30px 0;
 }
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 47.25%;
+  padding-top: 25px;
+  height: 0;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -139,6 +139,16 @@
             </div>
           </div>
         </div>
+        <div class="row">
+          <div class="col-md-3"></div>
+          <div class="col-md-6">
+            <div class="speaker">
+              <div class="more">
+                <p>See <a href="./schedule.html">the schedule</a> for info on speakers and talks</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -146,33 +156,38 @@
       <div class="container">
         <div class="row">
           <div class="col-xs-12">
-            <h2>About us</h2>
+            <h2>Why</h2>
           </div>
         </div>
         <div class="row">
           <div class="col-sm-4">
             <h3>It's fun</h3>
-            <p>Joy of coding is all about the love for programming. Learn about new and emerging technologies from companies and academia. Get inspired by renowned international speakers. Pair with fellow passionate developers in one of the workshops.</p>
+            <p>Joy of coding is all about the love for programming. Learn about new and emerging technologies from companies and academia. Get inspired by <a href="./schedule.html">renowned international speakers</a>. Pair with fellow passionate developers in one of <a href="./schedule.html">the workshops</a>.</p>
           </div>
           <div class="col-sm-4">
             <h3>It's affordable</h3>
-            <p>Joy of Coding is a non-profit event. With the help of our sponsors we aimed to keep registration fees low to provide the best value-for-money conference of 2016. Our very-early bird tickets start selling at only EUR 128, just like our previous editions!</p>
+            <p>Joy of Coding is a non-profit event. With the help of our sponsors we aimed to keep registration fees low to provide the best value-for-money conference of 2016. Our very-early bird <a href="http://inventid.to/joyofcoding">tickets</a> sell at only EUR 128, just like our previous editions!</p>
           </div>
           <div class="col-sm-4">
             <h3>It's by dev, for devs</h3>
-            <p>Joy of Coding is organised by a bunch of developers. There is no commercial agenda, the schedule is purely based on stuff that developers, like us, love to see. Expert speakers but no talking heads. A place where we can all get together and talk about code.</p>
+            <p>Joy of Coding is organised by <a href="./aboubt-us.html">a bunch of developers</a>. There is no commercial agenda, the schedule is purely based on stuff that developers, like us, love to see. Expert speakers but no talking heads. A place where we can all get together and talk about code.</p>
           </div>
         </div>
         <div class="row">
-          <div class="col-sm-7">
+          <div class="col-sm-5">
             <h3>Code of conduct</h3>
             <p>We are dedicated to providing an enjoyable, respectful and harassment-free event experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. &mdash; <a href="./code-of-conduct.html">full version</a></p>
           </div>
-          <div class="col-sm-5">
+          <div class="col-sm-7">
             <h3>Previous editions</h3>
-            <p>2015: <a href="/2015" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2015" target="_blank">videos</a></br>
-            2014: <a href="/2014" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157642055047693" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2014" target="_blank">videos</a></br>
-            2013: <a href="/2013" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157632915801638" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2013" target="_blank">videos</a></p>
+	    <p>
+              <div class="video-wrapper">
+                <iframe width="440" height="260" src="https://www.youtube.com/embed/LI2yOM4tODw" frameborder="0" allowfullscreen></iframe>
+              </div>
+	    </p>
+            <p>2015: <a href="/2015" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2015" target="_blank">recorded talks</a> - <a href="https://www.youtube.com/watch?v=LI2yOM4tODw">after movie</a></br>
+            2014: <a href="/2014" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157642055047693" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2014" target="_blank">recorded talks</a></br>
+            2013: <a href="/2013" target="_blank">website</a> - <a href="https://www.flickr.com/photos/joyofcoding/albums/72157632915801638" target="_blank">photos</a> - <a href="http://www.infoq.com/joy-of-coding-2013" target="_blank">recorded talks</a></p>
           </div>
         </div>
       </div>

--- a/venue.html
+++ b/venue.html
@@ -50,7 +50,7 @@
       <div class="container">
         <div class="row">
           <div class="col-sm-7 col-sm-offset-5">
-            <p class="intro">This year&rsquo;s Joy of Coding will take place in <a href="http://www.dedoelen.nl">De Doelen</a> a concert venue and convention center in Rotterdam. Although mainly known as a venue for classical music and jazz, it is also a superb conference location. The monumental building stands right in front of the Rotterdam Centraal train station.</p>
+            <p class="intro">This year&rsquo;s Joy of Coding will take place in <a href="http://www.dedoelen.nl">De Doelen</a>, a concert venue and convention center in Rotterdam. Although mainly known as a venue for classical music and jazz, it is also a superb conference location. The monumental building stands right in front of the Rotterdam Centraal train station.</p>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
- textual fixes/improvements (added some internal links also)
- added a "more info" link under the speaker photos on home to the schedule
- added the "after video", both as iframe (responsive) and as link, to both home and about-us
- renamed the "about us" section on home to "why"; as we also have an about us page